### PR TITLE
Inspect original class for decorators, not the deferred class

### DIFF
--- a/cachemodel/decorators.py
+++ b/cachemodel/decorators.py
@@ -49,13 +49,16 @@ def denormalized_field(field_name):
     if callable(field_name):
         # we were used without an argument
         raise ArgumentErrror("You must pass a field name to @denormalized_field")
-        
+
     return decorator
 
 def find_fields_decorated_with(instance, property_name):
     """helper function that finds all methods decorated with property_name"""
-    non_field_attributes = set(dir(instance.__class__)) - set(instance._meta.get_all_field_names())
+    klass = instance.__class__
+    if getattr(instance, '_deferred', False):
+        klass = instance._meta.proxy_for_model
+    non_field_attributes = set(dir(klass)) - set(instance._meta.get_all_field_names())
     for m in non_field_attributes:
-        if hasattr(getattr(instance.__class__, m), property_name):
-            yield getattr(instance.__class__, m)
+        if hasattr(getattr(klass, m), property_name):
+            yield getattr(klass, m)
 

--- a/cachemodel/models.py
+++ b/cachemodel/models.py
@@ -94,6 +94,7 @@ class CacheModel(models.Model):
 class CachedTable(models.Model):
     objects = models.Manager()
     cached = CachedTableManager()
+    model_version = 1
 
     class Meta:
         abstract = True

--- a/cachemodel/tests.py
+++ b/cachemodel/tests.py
@@ -132,6 +132,11 @@ class CacheModelTestCase(TestCase):
             self.assertEqual(new_foo.name, new_name)
 
 
+    def test_works_with_deferred(self):
+        """Load a deferred object and verify it saves"""
+        cat = Category(name='Foo', slug='foo').save()
 
+        with self.assertNumQueries(1):
+            cat = Category.objects.all().only('name')
 
-
+        cat.save()

--- a/cachemodel/tests.py
+++ b/cachemodel/tests.py
@@ -134,9 +134,8 @@ class CacheModelTestCase(TestCase):
 
     def test_works_with_deferred(self):
         """Load a deferred object and verify it saves"""
-        cat = Category(name='Foo', slug='foo').save()
+        user = Author(first_name='Foo', last_name='foo').save()
+        user = Author.objects.all().only('first_name')
 
-        with self.assertNumQueries(1):
-            cat = Category.objects.all().only('name')
+        user[0].save()
 
-        cat.save()

--- a/cachemodel/version.py
+++ b/cachemodel/version.py
@@ -1,1 +1,1 @@
-VERSION = (2, 1, 6)
+VERSION = (2, 1, 7)

--- a/tests/test_project/settings.py
+++ b/tests/test_project/settings.py
@@ -1,5 +1,11 @@
 # Django settings for test_project project.
 
+import os
+import sys
+
+PROJECT_ROOT = os.path.realpath(os.path.dirname(__file__) + '/../..')
+sys.path.insert(0, os.path.join(PROJECT_ROOT, ''))
+
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
@@ -140,7 +146,7 @@ import logging
 import sqlparse
 class sqlformatter(logging.Formatter):
     def format(self, record):
-        if record.sql:
+        if hasattr(record, 'sql'):
             return "\n" + sqlparse.format(record.sql, reindent=True, keyword_case="upper") + "\n"
 
 LOGGING = {


### PR DESCRIPTION
Saving an instance of a deferred object will throw because cachemodel looks for decorators on the deferred class (which confuses the __get__ method on the django model). So simply, if the object is deferred, use the original model class for inspection.

Test:
```
In [1]: from projects.models import Project

In [2]: p = Project.objects.filter(status=Project.PUBLISHED).only('id')

In [3]: p[0].save()

In [4]: p = Project.objects.filter(status=Project.PUBLISHED)

In [5]: p[0].save()
```

Not very eventful, and that's okay. Added test.